### PR TITLE
fix: No tests are found when no build.gradle[.kts] file present in root

### DIFF
--- a/lua/neotest-gradle/hooks/build_run_specification.lua
+++ b/lua/neotest-gradle/hooks/build_run_specification.lua
@@ -1,4 +1,5 @@
 local lib = require('neotest.lib')
+local logger = require('neotest.logging')
 local find_project_directory = require('neotest-gradle.hooks.find_project_directory')
 
 --- Fiends either an executable file named `gradlew` in any parent directory of
@@ -92,6 +93,8 @@ local function get_test_filter_arguments(tree, position)
       vim.list_extend(arguments, { '--tests', "'" .. namespace.id .. "'" })
     end
   end
+
+  logger.debug("test filter args: " .. vim.inspect(arguments))
 
   return arguments
 end

--- a/lua/neotest-gradle/hooks/discover_positions/build_position.lua
+++ b/lua/neotest-gradle/hooks/discover_positions/build_position.lua
@@ -8,31 +8,13 @@ local function get_captured_node_type(captured_nodes)
   end
 end
 
---- Try to convert camel case function names from Java to something more text
---- alike as you can do in Kotlin.
---- For example `itShouldFailIfBroken` becomes `it should fail if broken`.
---- Works not too well for many cases and is open to improvements.
----
---- @param text string
---- @return string
-local function camel_case_to_lower_case_with_whitespaces(text)
-  return (text:gsub('([A-Z])', function(character)
-    return ' ' .. character:lower()
-  end))
-end
-
---- Try to improve the raw function name into something nicely readable. This
---- includes removing "noisy" characters from the Treesitter parsing as well as
---- converting camel case naming and similar.
+--- Remove "noisy" characters from the Treesitter parsing
 ---
 --- @param name string - name of the test function
 --- @return string
 local function beautify_name(name)
   local clean_name = (name:gsub('`', ''):gsub('"', ''))
-  local has_whitespaces = clean_name:match(' ') and true or false
-  local descriptive_name = has_whitespaces and clean_name
-    or camel_case_to_lower_case_with_whitespaces(clean_name)
-  return (descriptive_name:gsub('^ ', ''))
+  return (clean_name:gsub('^ ', ''))
 end
 
 --- See neotest.lib.treesitter.ParseOptions.build_position

--- a/lua/neotest-gradle/hooks/find_project_directory.lua
+++ b/lua/neotest-gradle/hooks/find_project_directory.lua
@@ -1,3 +1,10 @@
 --- Construct function based on Neotest utility that finds root directory of
 --- a potential Gradle project based on certain indicator files.
-return require('neotest.lib').files.match_root_pattern('build.gradle', 'build.gradle.kts')
+return require('neotest.lib').files.match_root_pattern(
+  'build.gradle',
+  'build.gradle.kts',
+  'settings.gradle.kts',
+  'settings.gradle',
+  'gradlew',
+  'gradlew.bat'
+)

--- a/lua/neotest-gradle/hooks/shared_utilities.lua
+++ b/lua/neotest-gradle/hooks/shared_utilities.lua
@@ -1,10 +1,21 @@
 local lib = require('neotest.lib')
+local logger = require('neotest.logging')
 
 -- TODO: How to improve using Treesitter or similar?
 --- @param file_path string
 local function get_package_name(file_path)
-  local first_line = lib.files.read_lines(file_path)[1]
-  return (first_line:gsub('^package ', ''):gsub(';', ''))
+  local lines = lib.files.read_lines(file_path)
+  for _, line in ipairs(lines) do
+    if string.match(line, '^package ') then
+      local package_name = line:gsub('^package ', ''):gsub(';', '')
+
+      logger.debug('resolved package: ' .. package_name)
+      return package_name
+    end
+  end
+
+  logger.warn('failed to resolve a package in ' .. file_path)
+  return nil
 end
 
 return {


### PR DESCRIPTION
When there's no build.gradle[.kts] file present in a root folder of the project (which is the case if `gradle init` command is used), neotest-gradle can't run tests in this case.

Another issue is that if an empty build.gradle[.kts] file is added to the root, neotest-gradle still can't run tests because the filter command turns out to be invalid.

This PR is fixing both issues.